### PR TITLE
fix: getDirSizes function

### DIFF
--- a/bin/upload.js
+++ b/bin/upload.js
@@ -40,7 +40,7 @@ async function getShortCommitSHA() {
 async function appendRspackBuildInfo() {
 	const [commitSHA, shortCommitSHA] = await Promise.all([getCommitSHA(), getShortCommitSHA()]);
 	const buildInfoFile = join(dataDir, "build-info.json");
-	const buildInfo = existsSync(buildInfoFile) ? JSON.parse(await readFile(indexFile, "utf-8")) : {};
+	const buildInfo = existsSync(buildInfoFile) ? JSON.parse(await readFile(buildInfoFile, "utf-8")) : {};
 	buildInfo[date] = {
 		commitSHA,
 		shortCommitSHA,

--- a/docs/index.js
+++ b/docs/index.js
@@ -8,11 +8,13 @@ const formatTime = (value, maxValue) => {
 	if (maxValue > 10000) return `${value / 1000} s`;
 	return `${value} ms`;
 };
+
 const formatSize = (value, maxValue) => {
-	if (maxValue > 10000000) return `${value / 1000000} MB`;
-	if (maxValue > 10000) return `${value / 1000} kB`;
+	if (maxValue > 1000000) return `${(value / 1000000).toFixed(2)} MB`;
+	if (maxValue > 1000) return `${(value / 1000).toFixed(2)} KB`;
 	return `${value} B`;
 };
+
 const formatRatio = (value, maxValue) => {
 	return `${value}%`;
 };

--- a/lib/scenarios/utils.js
+++ b/lib/scenarios/utils.js
@@ -23,9 +23,11 @@ export async function clearCaches(directory) {
 
 export async function getDirSizes(directory) {
 	let size = 0;
-	await runCommand("du", ["-s", directory], {
-		onData(item) {
-			size = parseInt(item.toString()) * 1024;
+	await runCommand("du", ["-sk", directory], {
+		onData(stdio) {
+			const [sizeLiteral] = stdio.toString().split(' ').map(c => c.trim());
+			// Convert unit to B for compatibility with historical data
+			size = parseInt(sizeLiteral) * 1024;
 		}
 	});
 	return size;


### PR DESCRIPTION
The `getDirSizes` function uses the `du` shell command to determine the size of a directory. However, the `du` command's default size unit varies across different operating systems. To ensure consistency and clarity, it is advisable to explicitly specify the unit. Using `du -sk` specifies the size in KB, which standardizes the output regardless of the platform.

![image](https://github.com/web-infra-dev/rspack-ecosystem-benchmark/assets/19852293/aa56823b-11e1-47c0-b8cf-082a9967db04)