### PR TITLE
fix: use `fs.stat` to computed dir size

### DIFF
--- a/lib/scenarios/utils.js
+++ b/lib/scenarios/utils.js
@@ -1,6 +1,5 @@
 import * as fs from "fs/promises";
-import { resolve } from "path";
-import { runCommand } from "../utils.js";
+import { resolve, join } from "path";
 
 function rmdir(p) {
 	if (fs.rm) {
@@ -21,16 +20,10 @@ export async function clearCaches(directory) {
 	await Promise.all(paths.map(p => rmdir(resolve(directory, p))));
 }
 
-export async function getDirSizes(directory) {
-	let size = 0;
-	await runCommand("du", ["-sk", directory], {
-		onData(stdio) {
-			const [sizeLiteral] = stdio.toString().split(' ').map(c => c.trim());
-			// Convert unit to B for compatibility with historical data
-			size = parseInt(sizeLiteral) * 1024;
-		}
-	});
-	return size;
+export const getDirSizes = async directory => {
+  const files = await fs.readdir(directory);
+  const stats = files.map(file => fs.stat(join(directory, file)));
+  return (await Promise.all(stats)).reduce((sum, { size }) => sum + size, 0);
 }
 
 export async function getHmrConfig(filePath) {


### PR DESCRIPTION
I'm uncertain why the `du` shell command is yielding inaccurate results. To address this, I've switched to using the `fs.stat` function in JavaScript to calculate the directory size. Upon testing this approach in the workflow, the outcomes appear to be correct.

The workflow details are available here: https://github.com/web-infra-dev/rspack-ecosystem-benchmark/actions/runs/7635104400/job/20799989696