### PR TITLE
feat: store commit performance data

### DIFF
--- a/.github/workflows/scheduled_bench.yml
+++ b/.github/workflows/scheduled_bench.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+    inputs:
+      commit_id:
+        description: "the Commit to benchmark"
+        required: false
+        type: string
 
 permissions:
   # Allow `scheduled_bench` to write to `data` branch
@@ -16,8 +21,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Init env
         uses: ./.github/actions/env
-      - name: Build rspack
-        run: node bin/cli.js build
+      - name: Build rspack with ref
+        run: node bin/cli.js build --ref ${{ inputs.commit_id }}
       - name: Run benchmark
         run: node bin/cli.js bench
       - id: print-compare-results
@@ -31,8 +36,9 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Upload result
-        run: node bin/upload.js ${{ secrets.GITHUB_TOKEN }}
+        run: node bin/upload.js ${{ secrets.GITHUB_TOKEN }} ${{ inputs.commit_id}}
       - name: Check Threshold
+        if: ${{ inputs.commit_id == '' }}
         run: |
           result='${{ steps.print-compare-results.outputs.diff-result }}';
           if [[ $result =~ "Threshold exceeded" ]]; then

--- a/bin/upload.js
+++ b/bin/upload.js
@@ -4,9 +4,9 @@ import { resolve, join } from "path";
 import { fileURLToPath } from "url";
 import { runCommand, dirExist, formatDate } from "../lib/utils.js";
 
-const [, , token] = process.argv;
+const [, , token, toDist] = process.argv;
 const GITHUB_ACTOR = process.env.GITHUB_ACTOR;
-const date = formatDate(+new Date());
+const date = toDist || formatDate(+new Date());
 const repoUrl = `https://${GITHUB_ACTOR}:${token}@github.com/web-infra-dev/rspack-ecosystem-benchmark.git`;
 
 const rootDir = resolve(fileURLToPath(import.meta.url), "../..");

--- a/bin/upload.js
+++ b/bin/upload.js
@@ -4,16 +4,17 @@ import { resolve, join } from "path";
 import { fileURLToPath } from "url";
 import { runCommand, dirExist, formatDate } from "../lib/utils.js";
 
-const [, , token, toDist] = process.argv;
+const [, , token, sha] = process.argv;
 const GITHUB_ACTOR = process.env.GITHUB_ACTOR;
-const date = toDist || formatDate(+new Date());
+const dataTag = sha || formatDate(+new Date());
+const storeByDate = !sha;
 const repoUrl = `https://${GITHUB_ACTOR}:${token}@github.com/web-infra-dev/rspack-ecosystem-benchmark.git`;
 
 const rootDir = resolve(fileURLToPath(import.meta.url), "../..");
 const dataDir = resolve(rootDir, ".data");
 const outputDir = resolve(rootDir, "output");
 const rspackDir = process.env.RSPACK_DIR || resolve(rootDir, ".rspack");
-const dateDir = resolve(dataDir, date);
+const storeDir = resolve(dataDir, dataTag);
 
 async function getCommitSHA() {
 	let commitSHA;
@@ -32,7 +33,7 @@ async function appendRspackBuildInfo() {
 	const buildInfo = existsSync(buildInfoFile)
 		? JSON.parse(await readFile(buildInfoFile, "utf-8"))
 		: {};
-	buildInfo[date] = {
+	buildInfo[dataTag] = {
 		commitSHA
 	};
 	await writeFile(buildInfoFile, JSON.stringify(buildInfo, null, 2));
@@ -62,34 +63,39 @@ async function appendRspackBuildInfo() {
 	const files = new Set((await readFile(indexFile, "utf-8")).split("\n"));
 	files.delete("");
 
-	if (!(await dirExist(dateDir))) {
-		await mkdir(dateDir);
+	if (!(await dirExist(storeDir))) {
+		await mkdir(storeDir);
 	}
 	const outputFiles = await readdir(outputDir);
 	for (const item of outputFiles) {
 		if (item.endsWith(".json")) {
-			files.add(`${date}/${item}`);
+			files.add(`${dataTag}/${item}`);
 		}
-		await copyFile(resolve(outputDir, item), resolve(dateDir, item));
+		await copyFile(resolve(outputDir, item), resolve(storeDir, item));
 	}
 
-	console.log("== update index.txt ==");
-	await writeFile(indexFile, Array.from(files, f => `${f}\n`).join("") + "\n");
+	if (storeByDate) {
+		console.log("== update index.txt ==");
+		await writeFile(
+			indexFile,
+			Array.from(files, f => `${f}\n`).join("") + "\n"
+		);
 
-	console.log("== update build-info.json ==");
-	process.chdir(rspackDir);
-	await appendRspackBuildInfo();
+		console.log("== update build-info.json ==");
+		process.chdir(rspackDir);
+		await appendRspackBuildInfo();
+	}
 	process.chdir(dataDir);
 
 	console.log("== commit ==");
-	await runCommand("git", [
-		"add",
-		`${date}/*.json`,
-		"index.txt",
-		"build-info.json"
-	]);
+	await runCommand(
+		"git",
+		storeByDate
+			? ["add", `${dataTag}/*.json`, "index.txt", "build-info.json"]
+			: ["add", `${dataTag}/*.json`]
+	);
 	try {
-		await runCommand("git", ["commit", "-m", `"add ${date} results"`]);
+		await runCommand("git", ["commit", "-m", `"add ${dataTag} results"`]);
 	} catch {}
 
 	console.log("== push ==");


### PR DESCRIPTION
store performance datat by commit for easy find the donwgrade change commit

## usage

```bash
node bin/upload.js GITHUB_TOKEN sha1_commit_id
```

then the perf data will store at as below,(e.g. commit id is `15aa411a089296f27dc1422fdba4cedbdf73951b`)

`commits/15/aa411a089296f27dc1422fdba4cedbdf73951b/*.json`

if commit id isn't  provided, it will store data in date named dir eg. `2025-01-02/*.json`

