### PR TITLE
fix: config typo

### DIFF
--- a/cases/10000/rspack.config.js
+++ b/cases/10000/rspack.config.js
@@ -22,7 +22,7 @@ module.exports = {
 				exclude: [/[\\/]node_modules[\\/]/],
 				loader: "builtin:swc-loader",
 				options: {
-					sourceMap: true,
+					sourceMaps: true,
 					jsc: {
 						parser: {
 							syntax: "typescript"
@@ -39,7 +39,7 @@ module.exports = {
 				loader: "builtin:swc-loader",
 				exclude: [/[\\/]node_modules[\\/]/],
 				options: {
-					sourceMap: true,
+					sourceMaps: true,
 					jsc: {
 						parser: {
 							syntax: "typescript",

--- a/cases/large-dyn-imports/rspack.config.js
+++ b/cases/large-dyn-imports/rspack.config.js
@@ -29,7 +29,7 @@ module.exports = {
 				exclude: [/[\\/]node_modules[\\/]/],
 				loader: "builtin:swc-loader",
 				options: {
-					sourceMap: true,
+					sourceMaps: true,
 					jsc: {
 						parser: {
 							syntax: "typescript"
@@ -46,7 +46,7 @@ module.exports = {
 				loader: "builtin:swc-loader",
 				exclude: [/[\\/]node_modules[\\/]/],
 				options: {
-					sourceMap: true,
+					sourceMaps: true,
 					jsc: {
 						parser: {
 							syntax: "typescript",


### PR DESCRIPTION
it should be `sourceMaps` according to https://github.com/web-infra-dev/rspack/blob/46fdad1f9633e6fce5bb07b4803f3ded169c57ef/packages/rspack/src/builtin-loader/swc/types.ts#L468 and https://swc.rs/docs/configuration/compilation#sourcemaps 