### PR TITLE
Revert "fix: config typo"

### DIFF
--- a/cases/10000/rspack.config.js
+++ b/cases/10000/rspack.config.js
@@ -22,7 +22,7 @@ module.exports = {
 				exclude: [/[\\/]node_modules[\\/]/],
 				loader: "builtin:swc-loader",
 				options: {
-					sourceMaps: true,
+					sourceMap: true,
 					jsc: {
 						parser: {
 							syntax: "typescript"
@@ -39,7 +39,7 @@ module.exports = {
 				loader: "builtin:swc-loader",
 				exclude: [/[\\/]node_modules[\\/]/],
 				options: {
-					sourceMaps: true,
+					sourceMap: true,
 					jsc: {
 						parser: {
 							syntax: "typescript",

--- a/cases/10000/rspack.config.js
+++ b/cases/10000/rspack.config.js
@@ -22,7 +22,6 @@ module.exports = {
 				exclude: [/[\\/]node_modules[\\/]/],
 				loader: "builtin:swc-loader",
 				options: {
-					sourceMap: true,
 					jsc: {
 						parser: {
 							syntax: "typescript"
@@ -39,7 +38,6 @@ module.exports = {
 				loader: "builtin:swc-loader",
 				exclude: [/[\\/]node_modules[\\/]/],
 				options: {
-					sourceMap: true,
 					jsc: {
 						parser: {
 							syntax: "typescript",

--- a/cases/large-dyn-imports/rspack.config.js
+++ b/cases/large-dyn-imports/rspack.config.js
@@ -29,7 +29,6 @@ module.exports = {
 				exclude: [/[\\/]node_modules[\\/]/],
 				loader: "builtin:swc-loader",
 				options: {
-					sourceMap: true,
 					jsc: {
 						parser: {
 							syntax: "typescript"
@@ -46,7 +45,6 @@ module.exports = {
 				loader: "builtin:swc-loader",
 				exclude: [/[\\/]node_modules[\\/]/],
 				options: {
-					sourceMap: true,
 					jsc: {
 						parser: {
 							syntax: "typescript",

--- a/cases/large-dyn-imports/rspack.config.js
+++ b/cases/large-dyn-imports/rspack.config.js
@@ -29,7 +29,7 @@ module.exports = {
 				exclude: [/[\\/]node_modules[\\/]/],
 				loader: "builtin:swc-loader",
 				options: {
-					sourceMaps: true,
+					sourceMap: true,
 					jsc: {
 						parser: {
 							syntax: "typescript"
@@ -46,7 +46,7 @@ module.exports = {
 				loader: "builtin:swc-loader",
 				exclude: [/[\\/]node_modules[\\/]/],
 				options: {
-					sourceMaps: true,
+					sourceMap: true,
 					jsc: {
 						parser: {
 							syntax: "typescript",


### PR DESCRIPTION
Reverts web-infra-dev/rspack-ecosystem-benchmark#69

We should delete the typo other than fixing that, to keep the benchmark consistent with elder perf data's config