### PR TITLE
feat: support branch name as --base option for commit-based benchmark comparison

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -178,5 +178,5 @@ if (!command || command === "bench") {
 }
 
 if (!command || command === "compare") {
-	compare(base, current, benchmarkDirectory);
+	compare(base, current, benchmarkDirectory, repository);
 }

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -5,7 +5,10 @@ import { formatDiffTable } from "../lib/index.js";
 import {
 	fetchBuildInfo,
 	fetchIndex,
-	fetchBenchmarkResult
+	fetchBenchmarkResult,
+	fetchCommitFiles,
+	fetchCommitBenchmarkResult,
+	fetchRspackBranchCommits
 } from "../lib/services.js";
 
 function getOverThresholdTags(diff) {
@@ -53,6 +56,28 @@ function compareData(base, current) {
 	return diff;
 }
 
+async function getResultsByCommit(commitSHA, files) {
+	return Promise.all(
+		files.map(async file => ({
+			name: basename(file, ".json"),
+			result: await fetchCommitBenchmarkResult(commitSHA, file)
+		}))
+	);
+}
+
+// Walks back through the given branch's commits until one has benchmark data.
+async function findLatestCommitWithData(repository, branch) {
+	const commits = await fetchRspackBranchCommits(repository, branch);
+	for (const sha of commits) {
+		const files = await fetchCommitFiles(sha);
+		if (files && files.length > 0) {
+			return { sha, files };
+		}
+		console.log(`No benchmark data for commit ${sha.slice(0, 8)}, trying parent...`);
+	}
+	throw new Error(`No benchmark data found in the last ${commits.length} commits of ${repository}#${branch}`);
+}
+
 // get the result by date
 // `current` will get ../output data
 // `latest` will get the latest data on the data branch
@@ -96,17 +121,40 @@ function sortDiff(diff) {
 	return Object.fromEntries(sorted);
 }
 
-export async function compare(base, current, benchmarkDirectory) {
-	const index = await fetchIndex();
-	if (base === "latest") {
-		base = index[index.length - 1].date;
+export async function compare(base, current, benchmarkDirectory, repository = "web-infra-dev/rspack") {
+	let baseResults;
+	let baseLabel;
+	let baseCommitSHA;
+
+	const isDateOrSpecial = base === "latest" || base === "current" || /^\d{4}-\d{2}-\d{2}$/.test(base);
+	// index is needed when either base or current is resolved by date
+	const needIndex = isDateOrSpecial || current !== "current";
+	let index;
+
+	if (!isDateOrSpecial) {
+		// treat as a branch name, find the latest commit on that branch with data
+		const [commitResult, fetchedIndex] = await Promise.all([
+			findLatestCommitWithData(repository, base),
+			needIndex ? fetchIndex() : Promise.resolve(undefined)
+		]);
+		index = fetchedIndex;
+		const { sha, files } = commitResult;
+		baseResults = await getResultsByCommit(sha, files);
+		baseLabel = `${base}@${sha.slice(0, 8)}`;
+		baseCommitSHA = sha;
+	} else {
+		const [fetchedIndex, buildInfo] = await Promise.all([fetchIndex(), fetchBuildInfo()]);
+		index = fetchedIndex;
+		if (base === "latest") {
+			base = index[index.length - 1].date;
+		}
+		baseResults = await getResults(base, index, benchmarkDirectory);
+		baseLabel = base;
+		baseCommitSHA = buildInfo[base]?.commitSHA;
 	}
 
-	const [baseResults, currentResults, buildInfo] = await Promise.all([
-		getResults(base, index, benchmarkDirectory),
-		getResults(current, index, benchmarkDirectory),
-		fetchBuildInfo()
-	]);
+	const currentResults = await getResults(current, index, benchmarkDirectory);
+
 	const baseData = {};
 	const currentData = {};
 	for (const { name, result } of baseResults) {
@@ -128,8 +176,8 @@ export async function compare(base, current, benchmarkDirectory) {
 
 	const formatedTable = formatDiffTable({
 		diff: sortedDiff,
-		baseDate: base,
-		baseCommitSHA: buildInfo[base]?.commitSHA
+		baseDate: baseLabel,
+		baseCommitSHA
 	});
 	const overThresholdTags = getOverThresholdTags(sortedDiff);
 	console.log(formatedTable);

--- a/lib/services.js
+++ b/lib/services.js
@@ -54,7 +54,10 @@ export async function fetchBenchmarkResult(date, file) {
 }
 
 const githubApiPrefix = 'https://api.github.com';
-const githubApiHeaders = { Accept: 'application/vnd.github.v3+json' };
+const githubApiHeaders = {
+	Accept: 'application/vnd.github.v3+json',
+	...(process.env.GITHUB_TOKEN && { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` })
+};
 
 function getCommitDataPath(sha) {
 	return `commits/${sha.slice(0, 2)}/${sha.slice(2)}`;

--- a/lib/services.js
+++ b/lib/services.js
@@ -52,3 +52,56 @@ export async function fetchBenchmarkResult(date, file) {
 	const res = await fetch(`${fetchPrefix}/${date}/${file}`);
 	return await res.json();
 }
+
+const githubApiPrefix = 'https://api.github.com';
+const githubApiHeaders = { Accept: 'application/vnd.github.v3+json' };
+
+function getCommitDataPath(sha) {
+	return `commits/${sha.slice(0, 2)}/${sha.slice(2)}`;
+}
+
+/**
+ * Lists benchmark result files for a given commit SHA.
+ * Returns null if no data exists yet for that commit.
+ *
+ * @param {string} commitSHA
+ * @returns {Promise<string[] | null>}
+ */
+export async function fetchCommitFiles(commitSHA) {
+	const path = getCommitDataPath(commitSHA);
+	const res = await fetch(
+		`${githubApiPrefix}/repos/web-infra-dev/rspack-ecosystem-benchmark/contents/${path}?ref=data`,
+		{ headers: githubApiHeaders }
+	);
+	if (!res.ok) return null;
+	const items = await res.json();
+	return Array.isArray(items) ? items.map(f => f.name).filter(f => f.endsWith('.json')) : null;
+}
+
+/**
+ * @param {string} commitSHA
+ * @param {string} file
+ * @returns {Promise<{[key: string]: Object.<string, number>}>}
+ */
+export async function fetchCommitBenchmarkResult(commitSHA, file) {
+	const path = getCommitDataPath(commitSHA);
+	const res = await fetch(`${fetchPrefix}/${path}/${file}`);
+	return res.json();
+}
+
+/**
+ * Fetches recent commits from a branch of the rspack repository.
+ *
+ * @param {string} repository - e.g. "web-infra-dev/rspack"
+ * @param {string} branch - branch name, e.g. "main", "v1.x"
+ * @param {number} perPage
+ * @returns {Promise<string[]>} commit SHAs from newest to oldest
+ */
+export async function fetchRspackBranchCommits(repository, branch, perPage = 30) {
+	const res = await fetch(
+		`${githubApiPrefix}/repos/${repository}/commits?sha=${encodeURIComponent(branch)}&per_page=${perPage}`,
+		{ headers: githubApiHeaders }
+	);
+	const data = await res.json();
+	return data.map(c => c.sha);
+}


### PR DESCRIPTION
Added --base <branch> support (e.g. --base main, --base v1.x) to compare benchmark results against
   the latest commit on a given branch that has data
  - When the newest commit on the branch has no benchmark data yet, it automatically walks back through parent commits until one is found