### PR TITLE
feat: record both ci and release binary size

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -139,11 +139,6 @@ if (!command || command === "bench") {
 	let bindingSize = await getBinarySize(rspackDirectory);
 	let ciBindingSize = await getBinarySize(rspackDirectory, "ci");
 
-	console.log(
-		"debug",
-		JSON.stringify({ size: ciBindingSize, releaseSize: bindingSize }, null, 2)
-	);
-
 	await writeFile(
 		join(benchmarkDirectory, `rspack-build.json`),
 		JSON.stringify({ size: ciBindingSize, releaseSize: bindingSize }, null, 2)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,7 +6,7 @@ import { $, cd } from "zx";
 import actionsCore from "@actions/core";
 import { run, formatResultTable } from "../lib/index.js";
 import { isGitHubActions, dirExist } from "../lib/utils.js";
-import { getBinarySize } from "../lib/binary-size.js"
+import { getBinarySize } from "../lib/binary-size.js";
 import { compare } from "../lib/compare.js";
 import { generateCodeSplittingCase } from "../lib/gen-code-splitting-case.js";
 
@@ -137,9 +137,10 @@ if (!command || command === "bench") {
 
 	await mkdir(benchmarkDirectory, { recursive: true });
 	let bindingSize = await getBinarySize(rspackDirectory);
+	let ciBindingSize = await getBinarySize(rspackDirectory, "ci");
 	await writeFile(
 		join(benchmarkDirectory, `rspack-build.json`),
-		JSON.stringify({ size: bindingSize }, null, 2)
+		JSON.stringify({ size: ciBindingSize, releaseSize: bindingSize }, null, 2)
 	);
 
 	if (shardJobs.length) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -138,6 +138,12 @@ if (!command || command === "bench") {
 	await mkdir(benchmarkDirectory, { recursive: true });
 	let bindingSize = await getBinarySize(rspackDirectory);
 	let ciBindingSize = await getBinarySize(rspackDirectory, "ci");
+
+	console.log(
+		"debug",
+		JSON.stringify({ size: ciBindingSize, releaseSize: bindingSize }, null, 2)
+	);
+
 	await writeFile(
 		join(benchmarkDirectory, `rspack-build.json`),
 		JSON.stringify({ size: ciBindingSize, releaseSize: bindingSize }, null, 2)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -137,7 +137,7 @@ if (!command || command === "bench") {
 
 	await mkdir(benchmarkDirectory, { recursive: true });
 	let bindingSize = await getBinarySize(rspackDirectory);
-	let ciBindingSize = await getBinarySize(rspackDirectory, "ci");
+	let ciBindingSize = (await getBinarySize(rspackDirectory, "ci")) || bindingSize;
 
 	await writeFile(
 		join(benchmarkDirectory, `rspack-build.json`),

--- a/lib/binary-size.js
+++ b/lib/binary-size.js
@@ -1,18 +1,25 @@
 import { stat } from "node:fs/promises";
-import { join } from "path"
+import { join } from "path";
 import { platform, arch } from "node:process";
 
 function getBinaryName() {
-  if (platform === 'darwin') {
-	if (arch === 'arm64') {
-		return 'rspack.darwin-arm64.node'
+	if (platform === "darwin") {
+		if (arch === "arm64") {
+			return "rspack.darwin-arm64.node";
+		}
 	}
-  }
-  return 'rspack.linux-x64-gnu.node';
+	return "rspack.linux-x64-gnu.node";
 }
 
-export async function getBinarySize (rspackDir) {
-	let binaryPath = join(rspackDir, `crates/node_binding/${getBinaryName()}`)
-	let binaryStat = await stat(binaryPath)
-	return binaryStat.size
+export async function getBinarySize(rspackDir, profile = "") {
+	let binaryPath = profile
+		? join(rspackDir, `crates/node_binding/${getBinaryName()}`)
+		: join(rspackDir, `crates/node_binding/${profile}/${getBinaryName()}`);
+
+	try {
+		let binaryStat = await stat(binaryPath);
+		return binaryStat.size;
+	} catch (e) {
+		return 0;
+	}
 }

--- a/lib/binary-size.js
+++ b/lib/binary-size.js
@@ -11,10 +11,10 @@ function getBinaryName() {
 	return "rspack.linux-x64-gnu.node";
 }
 
-export async function getBinarySize(rspackDir, profile = "") {
+export async function getBinarySize(rspackDir, profile) {
 	let binaryPath = profile
-		? join(rspackDir, `crates/node_binding/${getBinaryName()}`)
-		: join(rspackDir, `crates/node_binding/${profile}/${getBinaryName()}`);
+		? join(rspackDir, `crates/node_binding/${profile}/${getBinaryName()}`)
+		: join(rspackDir, `crates/node_binding/${getBinaryName()}`);
 
 	try {
 		let binaryStat = await stat(binaryPath);


### PR DESCRIPTION
## Summary
- Collect both CI-profile and release-profile binary sizes in `rspack-build.json` (adds `releaseSize` alongside `size`)
- Make `getBinarySize` accept a `profile` arg and tolerate missing binaries by returning 0

## Test plan
- [ ] Run a benchmark locally and confirm `rspack-build.json` contains both `size` (ci) and `releaseSize`
- [ ] Confirm behavior when only one profile's binary exists (missing one should yield 0, not throw)