### PR TITLE
chore: add format script and CI format check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,29 @@
+name: Format Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+jobs:
+  format:
+    name: Prettier Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.14.3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run format:check

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,13 +17,13 @@ jobs:
     name: Prettier Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
         with:
           version: 8.14.3
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run format:check

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,6 +8,9 @@ on:
     types: [opened, synchronize]
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@ output/**
 cases/**
 pnpm-lock.yaml
 pnpm-workspace.yaml
+.vscode/
+lib/addons/big/react.js

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,22 +1,3 @@
 {
-	"printWidth": 80,
-	"useTabs": true,
-	"tabWidth": 2,
-	"trailingComma": "none",
-	"arrowParens": "avoid",
-	"overrides": [
-		{
-			"files": "*.json",
-			"options": {
-				"parser": "json",
-				"useTabs": false
-			}
-		},
-		{
-			"files": "*.ts",
-			"options": {
-				"parser": "typescript"
-			}
-		}
-	]
+  "singleQuote": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,5 @@
 {
-  "singleQuote": true
+	"singleQuote": false,
+	"arrowParens": "avoid",
+	"printWidth": 120
 }

--- a/bench.config.js
+++ b/bench.config.js
@@ -25,7 +25,7 @@ export default {
 		"threejs_production-mode_10x_persistent-cold",
 		"threejs_production-mode_10x_persistent-hot",
 		"bundled-threejs_development-mode",
-		"bundled-threejs_production-mode"
+		"bundled-threejs_production-mode",
 	],
-	rspackDirectory: process.env.RSPACK_DIR
+	rspackDirectory: process.env.RSPACK_DIR,
 };

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -18,42 +18,42 @@ const cli = meow({
 		// Rspack repository name.
 		repository: {
 			type: "string",
-			default: "web-infra-dev/rspack"
+			default: "web-infra-dev/rspack",
 		},
 		// The branch, tag or SHA to checkout. When checking out the repository that
 		// triggered a workflow, this defaults to the reference or SHA for that event.
 		// Otherwise, uses the default branch.
 		ref: {
 			type: "string",
-			default: "main"
+			default: "main",
 		},
 
 		binding: {
 			type: "boolean",
-			default: true
+			default: true,
 		},
 		js: {
 			type: "boolean",
-			default: true
+			default: true,
 		},
 		job: {
 			type: "string",
-			isMultiple: true
+			isMultiple: true,
 		},
 		shard: {
 			type: "string",
-			default: "1/1"
+			default: "1/1",
 		},
 
 		base: {
 			type: "string",
-			default: "latest"
+			default: "latest",
 		},
 		current: {
 			type: "string",
-			default: "current"
-		}
-	}
+			default: "current",
+		},
+	},
 });
 
 const command = cli.input.at(0);
@@ -69,7 +69,7 @@ const {
 	shard,
 
 	base,
-	current
+	current,
 } = cli.flags;
 
 const cwd = process.cwd();
@@ -94,9 +94,7 @@ if (!command || command === "build") {
 
 	await $`git add * || echo "ok"`;
 	await $`git reset --hard`;
-	const currentBranch = (await $`git rev-parse --abbrev-ref HEAD`)
-		.toString()
-		.trim();
+	const currentBranch = (await $`git rev-parse --abbrev-ref HEAD`).toString().trim();
 	await $`git fetch ${fetchUrl} ${ref} --prune`;
 	await $`git checkout -b ${Date.now()} FETCH_HEAD`;
 	if (currentBranch) {
@@ -130,10 +128,7 @@ if (!command || command === "bench") {
 	const [currentIndex, totalShards] = shardPair;
 
 	const shardSize = Math.ceil(jobs.length / totalShards);
-	const shardJobs = jobs.slice(
-		shardSize * (currentIndex - 1),
-		shardSize * currentIndex
-	);
+	const shardJobs = jobs.slice(shardSize * (currentIndex - 1), shardSize * currentIndex);
 
 	await mkdir(benchmarkDirectory, { recursive: true });
 	let bindingSize = await getBinarySize(rspackDirectory);
@@ -145,12 +140,7 @@ if (!command || command === "bench") {
 	);
 
 	if (shardJobs.length) {
-		console.log(
-			[
-				`Running jobs for shard ${currentIndex}/${totalShards}:`,
-				...shardJobs
-			].join("\n  * ")
-		);
+		console.log([`Running jobs for shard ${currentIndex}/${totalShards}:`, ...shardJobs].join("\n  * "));
 
 		for (const job of shardJobs) {
 			const start = Date.now();
@@ -169,10 +159,7 @@ if (!command || command === "bench") {
 				console.log(`Cost for \`${job}\`: ${cost} s`);
 			}
 
-			await writeFile(
-				join(benchmarkDirectory, `${job}.json`),
-				JSON.stringify(result, null, 2)
-			);
+			await writeFile(join(benchmarkDirectory, `${job}.json`), JSON.stringify(result, null, 2));
 		}
 	} else {
 		console.log(`No jobs to run for shard ${currentIndex}/${totalShards}.`);

--- a/bin/upload.js
+++ b/bin/upload.js
@@ -8,9 +8,7 @@ const [, , token, sha] = process.argv;
 const storeByDate = !sha;
 const GITHUB_ACTOR = process.env.GITHUB_ACTOR;
 const dataTag = storeByDate ? formatDate(+new Date()) : sha.slice(0, 8);
-const relativePath = storeByDate
-	? dataTag
-	: join("commits", sha.slice(0, 2), sha.slice(2));
+const relativePath = storeByDate ? dataTag : join("commits", sha.slice(0, 2), sha.slice(2));
 const repoUrl = `https://${GITHUB_ACTOR}:${token}@github.com/web-infra-dev/rspack-ecosystem-benchmark.git`;
 
 const rootDir = resolve(fileURLToPath(import.meta.url), "../..");
@@ -24,7 +22,7 @@ async function getCommitSHA() {
 	await runCommand("git", ["rev-parse", "HEAD"], {
 		onData(stdout) {
 			commitSHA = stdout.toString().trim();
-		}
+		},
 	});
 	console.log("Current Commit SHA", commitSHA);
 	return commitSHA;
@@ -33,27 +31,16 @@ async function getCommitSHA() {
 async function appendRspackBuildInfo() {
 	const commitSHA = await getCommitSHA();
 	const buildInfoFile = join(dataDir, "build-info.json");
-	const buildInfo = existsSync(buildInfoFile)
-		? JSON.parse(await readFile(buildInfoFile, "utf-8"))
-		: {};
+	const buildInfo = existsSync(buildInfoFile) ? JSON.parse(await readFile(buildInfoFile, "utf-8")) : {};
 	buildInfo[dataTag] = {
-		commitSHA
+		commitSHA,
 	};
 	await writeFile(buildInfoFile, JSON.stringify(buildInfo, null, 2));
 }
 
 (async () => {
 	if (!(await dirExist(dataDir))) {
-		await runCommand("git", [
-			"clone",
-			"--branch",
-			"data",
-			"--single-branch",
-			"--depth",
-			"1",
-			repoUrl,
-			".data"
-		]);
+		await runCommand("git", ["clone", "--branch", "data", "--single-branch", "--depth", "1", repoUrl, ".data"]);
 	}
 
 	process.chdir(dataDir);
@@ -79,10 +66,7 @@ async function appendRspackBuildInfo() {
 
 	if (storeByDate) {
 		console.log("== update index.txt ==");
-		await writeFile(
-			indexFile,
-			Array.from(files, f => `${f}\n`).join("") + "\n"
-		);
+		await writeFile(indexFile, Array.from(files, f => `${f}\n`).join("") + "\n");
 
 		console.log("== update build-info.json ==");
 		process.chdir(rspackDir);
@@ -93,9 +77,7 @@ async function appendRspackBuildInfo() {
 	console.log("== commit ==");
 	await runCommand(
 		"git",
-		storeByDate
-			? ["add", `${relativePath}/*.json`, "index.txt", "build-info.json"]
-			: ["add", `${relativePath}/*.json`]
+		storeByDate ? ["add", `${relativePath}/*.json`, "index.txt", "build-info.json"] : ["add", `${relativePath}/*.json`]
 	);
 	try {
 		await runCommand("git", ["commit", "-m", `"add ${dataTag} results"`]);

--- a/docs/by_commits.html
+++ b/docs/by_commits.html
@@ -22,7 +22,7 @@
 			<canvas id="perf-chart"></canvas>
 		</div>
 
-		<h1> Binary Size </h1>
+		<h1>Binary Size</h1>
 		<div class="chart-container">
 			<canvas id="size-chart"></canvas>
 		</div>

--- a/docs/by_commits.js
+++ b/docs/by_commits.js
@@ -68,7 +68,7 @@ const allBenchmarkNames = [
 	"threejs_production-mode_10x",
 	"threejs_production-mode_10x_persistent-cold",
 	"threejs_production-mode_10x_persistent-hot",
-	"threejs_production-mode_builtin-swc-loader_10x"
+	"threejs_production-mode_builtin-swc-loader_10x",
 ];
 
 const metrics = [
@@ -121,7 +121,7 @@ const metrics = [
 	"exec",
 	"external memory",
 	"heap memory",
-	"rss memory"
+	"rss memory",
 ];
 
 class DataCenter {
@@ -146,16 +146,13 @@ class DataCenter {
 		const perPage = parseInt(queryParams.get("per_page") || "50", 10) || 50;
 
 		try {
-			const commits = await fetch(
-				`https://api.github.com/repos/web-infra-dev/rspack/commits?per_page=${perPage}`,
-				{
-					headers: this.githubToken
-						? {
-								Authorization: `Bearer ${this.githubToken}`
-						  }
-						: {}
-				}
-			).then(res => {
+			const commits = await fetch(`https://api.github.com/repos/web-infra-dev/rspack/commits?per_page=${perPage}`, {
+				headers: this.githubToken
+					? {
+							Authorization: `Bearer ${this.githubToken}`,
+					  }
+					: {},
+			}).then(res => {
 				if (!res.ok) {
 					showGithubTokenModal();
 
@@ -169,7 +166,7 @@ class DataCenter {
 					sha,
 					url: html_url,
 					message,
-					author
+					author,
 				}))
 				.reverse();
 
@@ -187,17 +184,11 @@ class DataCenter {
 				if (!this.cache[benchmarkName]) {
 					this.cache[benchmarkName] = await Promise.all(
 						this.commits.map(({ sha, author, url, message }) => {
-							let description = `${message.split("\n")[0].trim()} by @${
-								author.name
-							}`;
+							let description = `${message.split("\n")[0].trim()} by @${author.name}`;
 							let date = moment(author.date).format("YYYY-MM-DD");
 							let labelX = `${sha.slice(0, 7)}:${date}`;
 
-							return fetch(
-								`${fetchPrefix}/commits/${sha.slice(0, 2)}/${sha.slice(
-									2
-								)}/${benchmarkName}.json`
-							)
+							return fetch(`${fetchPrefix}/commits/${sha.slice(0, 2)}/${sha.slice(2)}/${benchmarkName}.json`)
 								.then(
 									res => res.json(),
 									() => ({})
@@ -219,7 +210,7 @@ class DataCenter {
 						if (typeof file[metric] === "number") {
 							return {
 								value: file[metric],
-								...rest
+								...rest,
 							};
 						}
 
@@ -228,7 +219,7 @@ class DataCenter {
 						}
 						return {
 							value: file[metric].median,
-							...rest
+							...rest,
 						};
 					})
 					.filter(item => !!item);
@@ -362,7 +353,7 @@ class BenchmarkChart {
 		this.chart = new Chart(document.querySelector(selector), {
 			type: "line",
 			data: {
-				datasets: []
+				datasets: [],
 			},
 			options: {
 				onClick(event, activeElements) {
@@ -379,8 +370,8 @@ class BenchmarkChart {
 				scales: {
 					x: {
 						ticks: {
-							autoSkip: false
-						}
+							autoSkip: false,
+						},
 					},
 					time: {
 						type: "linear",
@@ -390,8 +381,8 @@ class BenchmarkChart {
 						ticks: {
 							callback(value, _, values) {
 								return formatTime(value, values[values.length - 1].value);
-							}
-						}
+							},
+						},
 					},
 					size: {
 						type: "linear",
@@ -401,8 +392,8 @@ class BenchmarkChart {
 						ticks: {
 							callback(value, _, values) {
 								return formatSize(value, values[values.length - 1].value);
-							}
-						}
+							},
+						},
 					},
 					ratio: {
 						type: "linear",
@@ -412,14 +403,14 @@ class BenchmarkChart {
 						ticks: {
 							callback(value, _, values) {
 								return formatRatio(value, values[values.length - 1].value);
-							}
-						}
-					}
+							},
+						},
+					},
 				},
 				plugins: {
 					legend: {
 						// ignore click event
-						onClick: function () {}
+						onClick: function () {},
 					},
 					tooltip: {
 						callbacks: {
@@ -447,15 +438,12 @@ class BenchmarkChart {
 									deltaText = ` (${sign}${delta.toFixed(2)}%)`;
 								}
 
-								return [
-									`${context.dataset.label}: ${text}${deltaText}`,
-									`${context.raw.description}`
-								];
-							}
-						}
-					}
-				}
-			}
+								return [`${context.dataset.label}: ${text}${deltaText}`, `${context.raw.description}`];
+							},
+						},
+					},
+				},
+			},
 		});
 	}
 
@@ -473,7 +461,7 @@ class BenchmarkChart {
 		const axisValues = {
 			time: [],
 			size: [],
-			ratio: []
+			ratio: [],
 		};
 
 		for (const tag of Object.keys(data)) {
@@ -492,11 +480,11 @@ class BenchmarkChart {
 							x: labelX,
 							y: value,
 							url,
-							description
+							description,
 						};
 					}),
 				yAxisID: axis,
-				fill: true
+				fill: true,
 			});
 			// this.chart.data.labels = values.map(v=>v.sha.slice(0,7))
 		}
@@ -574,17 +562,15 @@ function showGithubTokenModal() {
 	`;
 	document.body.appendChild(modal);
 
-	document
-		.getElementById("github-token-submit")
-		.addEventListener("click", () => {
-			const token = document.getElementById("github-token-input").value.trim();
-			if (token) {
-				localStorage.setItem("GITHUB_TOKEN", token);
-				location.reload();
-			} else {
-				alert("Empty Token");
-			}
-		});
+	document.getElementById("github-token-submit").addEventListener("click", () => {
+		const token = document.getElementById("github-token-input").value.trim();
+		if (token) {
+			localStorage.setItem("GITHUB_TOKEN", token);
+			location.reload();
+		} else {
+			alert("Empty Token");
+		}
+	});
 }
 
 (async function () {
@@ -598,12 +584,7 @@ function showGithubTokenModal() {
 		chart.updateChartData(tags);
 	});
 
-	initializeAddAction(
-		allBenchmarkNames,
-		dataCenter.metrics,
-		tagCtrl.has.bind(tagCtrl),
-		tagCtrl.add.bind(tagCtrl)
-	);
+	initializeAddAction(allBenchmarkNames, dataCenter.metrics, tagCtrl.has.bind(tagCtrl), tagCtrl.add.bind(tagCtrl));
 
 	let tag = "rspack-build + size";
 	await dataCenter.fetchChartData(["rspack-build + size"]);

--- a/docs/index.js
+++ b/docs/index.js
@@ -4,7 +4,7 @@
 
 const getFetchPrefix = () => {
 	return "https://raw.githubusercontent.com/web-infra-dev/rspack-ecosystem-benchmark/data";
-}
+};
 
 const fetchPrefix = getFetchPrefix();
 
@@ -59,7 +59,7 @@ class DataCenter {
 		const index = {};
 		const [indexFile] = await Promise.all([
 			fetch(`${fetchPrefix}/index.txt`).then(res => res.text()),
-			this.fetchBuildInfo()
+			this.fetchBuildInfo(),
 		]);
 		const lines = indexFile.split("\n").filter(item => !!item);
 		const beginDate = lines[0].split("/")[0];
@@ -77,9 +77,7 @@ class DataCenter {
 		this.index = index;
 
 		// generate metrics struct
-		const latestData = await fetch(`${fetchPrefix}/${lines.pop()}`).then(res =>
-			res.json()
-		);
+		const latestData = await fetch(`${fetchPrefix}/${lines.pop()}`).then(res => res.json());
 		this.metrics = Object.keys(latestData);
 
 		// set date range
@@ -88,19 +86,14 @@ class DataCenter {
 
 	async fetchBuildInfo() {
 		try {
-			this.buildInfo = await fetch(`${fetchPrefix}/build-info.json`).then(
-				res => {
-					if (!res.ok) {
-						throw new Error(`Request failed with status code ${res.status}`);
-					}
-					return res.json();
+			this.buildInfo = await fetch(`${fetchPrefix}/build-info.json`).then(res => {
+				if (!res.ok) {
+					throw new Error(`Request failed with status code ${res.status}`);
 				}
-			);
+				return res.json();
+			});
 		} catch (err) {
-			console.log(
-				"Error occurred while fetching build-info.json: ",
-				err.message
-			);
+			console.log("Error occurred while fetching build-info.json: ", err.message);
 		}
 	}
 
@@ -113,9 +106,7 @@ class DataCenter {
 					this.cache[benchmarkName] = await Promise.all(
 						// only get the latest 90 days metric for performance reason
 						this.index[benchmarkName].slice(-180).map(async date => {
-							const file = await fetch(
-								`${fetchPrefix}/${date}/${benchmarkName}.json`
-							).then(res => res.json());
+							const file = await fetch(`${fetchPrefix}/${date}/${benchmarkName}.json`).then(res => res.json());
 							return { date, file };
 						})
 					);
@@ -128,7 +119,7 @@ class DataCenter {
 						}
 						return {
 							date,
-							value: file[metric].median
+							value: file[metric].median,
 						};
 					})
 					.filter(item => !!item);
@@ -255,7 +246,7 @@ class BenchmarkChart {
 		this.chart = new Chart(document.querySelector(".chart-container canvas"), {
 			type: "line",
 			data: {
-				datasets: []
+				datasets: [],
 			},
 			options: {
 				onClick(event, activeElements) {
@@ -266,23 +257,20 @@ class BenchmarkChart {
 					const { x } = this.data.datasets[datasetIndex].data[index];
 					const commitSHA = buildInfo[x] ? buildInfo[x].commitSHA : null;
 					if (commitSHA) {
-						window.open(
-							`https://github.com/web-infra-dev/rspack/commit/${commitSHA}`,
-							"_blank"
-						);
+						window.open(`https://github.com/web-infra-dev/rspack/commit/${commitSHA}`, "_blank");
 					}
 				},
 				scales: {
 					x: {
 						type: "time",
 						time: {
-							unit: "day"
+							unit: "day",
 						},
 						ticks: {
 							callback(v) {
 								return moment(v).format("YYYY-MM-DD");
-							}
-						}
+							},
+						},
 					},
 					time: {
 						type: "linear",
@@ -292,8 +280,8 @@ class BenchmarkChart {
 						ticks: {
 							callback(value, _, values) {
 								return formatTime(value, values[values.length - 1].value);
-							}
-						}
+							},
+						},
 					},
 					size: {
 						type: "linear",
@@ -303,8 +291,8 @@ class BenchmarkChart {
 						ticks: {
 							callback(value, _, values) {
 								return formatSize(value, values[values.length - 1].value);
-							}
-						}
+							},
+						},
 					},
 					ratio: {
 						type: "linear",
@@ -314,24 +302,21 @@ class BenchmarkChart {
 						ticks: {
 							callback(value, _, values) {
 								return formatRatio(value, values[values.length - 1].value);
-							}
-						}
-					}
+							},
+						},
+					},
 				},
 				plugins: {
 					legend: {
 						// ignore click event
-						onClick: function () { }
+						onClick: function () {},
 					},
 					tooltip: {
 						callbacks: {
 							title(context) {
 								const date = context[0].raw.x;
 								if (buildInfo[date] && buildInfo[date].commitSHA) {
-									return [
-										date,
-										`commit sha: ${buildInfo[date].commitSHA.slice(0, 7)}`
-									];
+									return [date, `commit sha: ${buildInfo[date].commitSHA.slice(0, 7)}`];
 								}
 								return date;
 							},
@@ -341,14 +326,14 @@ class BenchmarkChart {
 									context.dataset.yAxisID === "size"
 										? formatSize(value, value)
 										: context.dataset.yAxisID === "ratio"
-											? formatRatio(value, value)
-											: formatTime(value, value);
+										? formatRatio(value, value)
+										: formatTime(value, value);
 								return `${context.dataset.label}: ${text}`;
-							}
-						}
-					}
-				}
-			}
+							},
+						},
+					},
+				},
+			},
 		});
 	}
 
@@ -366,7 +351,7 @@ class BenchmarkChart {
 		const axisValues = {
 			time: [],
 			size: [],
-			ratio: []
+			ratio: [],
 		};
 
 		for (const tag of Object.keys(data)) {
@@ -381,11 +366,11 @@ class BenchmarkChart {
 					axisValues[axis].push(value);
 					return {
 						x: date,
-						y: value
+						y: value,
 					};
 				}),
 				yAxisID: axis,
-				fill: true
+				fill: true,
 			});
 		}
 		this.chart.data.datasets = datasets;
@@ -434,10 +419,7 @@ function initializeSlider(onChange) {
 		debounceChange(l1, l2);
 	};
 	const updateActiveLinePos = function () {
-		const [l1, l2] = [
-			parseInt(markDom1.style.left),
-			parseInt(markDom2.style.left)
-		].sort((a, b) => a - b);
+		const [l1, l2] = [parseInt(markDom1.style.left), parseInt(markDom2.style.left)].sort((a, b) => a - b);
 		activeLineDom.style.left = l1 + "%";
 		activeLineDom.style.width = l2 - l1 + "%";
 		debounceChange(l1, l2);
@@ -447,9 +429,7 @@ function initializeSlider(onChange) {
 	let baseLeft = 0;
 	let baseX = 0;
 	const handleMouseMove = function (e) {
-		const diff = Math.floor(
-			((e.clientX - baseX) * 100) / container.clientWidth + 0.5
-		);
+		const diff = Math.floor(((e.clientX - baseX) * 100) / container.clientWidth + 0.5);
 		const nextLeft = Math.min(Math.max(0, diff + baseLeft), 100);
 		const currentLeft = parseInt(movingDom.style.left);
 		if (currentLeft === nextLeft) {

--- a/lib/addons/10x/index.js
+++ b/lib/addons/10x/index.js
@@ -2,14 +2,11 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { Addon } from "../common.js";
 
-const loaderPath = path.resolve(
-	fileURLToPath(import.meta.url),
-	"../loader.cjs"
-);
+const loaderPath = path.resolve(fileURLToPath(import.meta.url), "../loader.cjs");
 
 export default class extends Addon {
 	options = {
-		times: 10
+		times: 10,
 	};
 	async afterSetup(ctx) {
 		// TODO use loader

--- a/lib/addons/big/index.js
+++ b/lib/addons/big/index.js
@@ -12,41 +12,41 @@ const FUNCTION_CODE = fs.readFileSync(path.join(__dirname, "react.js"), "utf-8")
 let srcDir;
 
 export default class extends Addon {
-    async afterSetup(ctx) {
-        srcDir = path.join(ctx.caseDir, 'src');
+	async afterSetup(ctx) {
+		srcDir = path.join(ctx.caseDir, "src");
 
-        function addFunctionToFile(filePath) {
-            try {
-                const data = fs.readFileSync(filePath, 'utf8');
-                const updatedData = data + FUNCTION_CODE;
-                fs.writeFileSync(filePath, updatedData, 'utf8');
-            } catch (err) {
-                console.error(`Error processing file ${filePath}:`, err);
-            }
-        }
+		function addFunctionToFile(filePath) {
+			try {
+				const data = fs.readFileSync(filePath, "utf8");
+				const updatedData = data + FUNCTION_CODE;
+				fs.writeFileSync(filePath, updatedData, "utf8");
+			} catch (err) {
+				console.error(`Error processing file ${filePath}:`, err);
+			}
+		}
 
-        function processDirectory(directory) {
-            try {
-                const items = fs.readdirSync(directory);
-                items.forEach(item => {
-                    const itemPath = path.join(directory, item);
-                    if (fs.lstatSync(itemPath).isDirectory()) {
-                        processDirectory(itemPath);
-                    } else if (fs.lstatSync(itemPath).isFile()) {
-                        addFunctionToFile(itemPath);
-                    }
-                });
-            } catch (err) {
-                console.error(`Error reading directory ${directory}:`, err);
-            }
-        }
+		function processDirectory(directory) {
+			try {
+				const items = fs.readdirSync(directory);
+				items.forEach(item => {
+					const itemPath = path.join(directory, item);
+					if (fs.lstatSync(itemPath).isDirectory()) {
+						processDirectory(itemPath);
+					} else if (fs.lstatSync(itemPath).isFile()) {
+						addFunctionToFile(itemPath);
+					}
+				});
+			} catch (err) {
+				console.error(`Error reading directory ${directory}:`, err);
+			}
+		}
 
-        processDirectory(srcDir);
-    }
+		processDirectory(srcDir);
+	}
 
-    async afterTeardown() {
-        if (srcDir) {
-            await $`git checkout ${srcDir}`;
-        }
-    }
+	async afterTeardown() {
+		if (srcDir) {
+			await $`git checkout ${srcDir}`;
+		}
+	}
 }

--- a/lib/addons/generate-package-json-webpack-plugin.js
+++ b/lib/addons/generate-package-json-webpack-plugin.js
@@ -2,7 +2,7 @@ import { Addon } from "./common.js";
 
 export default class extends Addon {
 	options = {
-		times: 10
+		times: 10,
 	};
 	async afterSetup(ctx) {
 		ctx.config =

--- a/lib/addons/noop-loader/index.js
+++ b/lib/addons/noop-loader/index.js
@@ -2,10 +2,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { Addon } from "../common.js";
 
-const loaderPath = path.resolve(
-	fileURLToPath(import.meta.url),
-	"../loader.cjs"
-);
+const loaderPath = path.resolve(fileURLToPath(import.meta.url), "../loader.cjs");
 
 export default class extends Addon {
 	async afterSetup(ctx) {

--- a/lib/addons/noop-loader/loader.cjs
+++ b/lib/addons/noop-loader/loader.cjs
@@ -1,3 +1,3 @@
 module.exports = function (source) {
-    return source
-}
+	return source;
+};

--- a/lib/addons/traverse-chunk-modules/index.js
+++ b/lib/addons/traverse-chunk-modules/index.js
@@ -7,7 +7,7 @@ const pluginPath = path.join(__dirname, "plugin.cjs");
 
 export default class extends Addon {
 	options = {
-		times: 10
+		times: 10,
 	};
 	async afterSetup(ctx) {
 		ctx.config =

--- a/lib/addons/traverse-chunk-modules/plugin.cjs
+++ b/lib/addons/traverse-chunk-modules/plugin.cjs
@@ -19,7 +19,7 @@ class TraverseChunkModulesPlugin {
 					}
 				}
 
-				console.log('visited modules number', visitedModules.size);
+				console.log("visited modules number", visitedModules.size);
 			});
 		});
 	}

--- a/lib/bench.js
+++ b/lib/bench.js
@@ -13,9 +13,7 @@ export async function run(benchmarkName) {
 	const addons = await Promise.all(
 		addonNames.map(async name => {
 			const hasDir = await dirExist(path.resolve(dirname, `./addons/${name}/`));
-			const Addon = hasDir
-				? await import(`./addons/${name}/index.js`)
-				: await import(`./addons/${name}.js`);
+			const Addon = hasDir ? await import(`./addons/${name}/index.js`) : await import(`./addons/${name}.js`);
 			return new Addon.default();
 		})
 	);

--- a/lib/code-splitting-case-random-table.js
+++ b/lib/code-splitting-case-random-table.js
@@ -1,29 +1,33 @@
 import fs from "fs/promises";
 import path from "path";
 import { fileURLToPath } from "node:url";
-import { NUM_STATIC_MODULES, NUM_REUSE_IMPORTS_PER_MODULE, NUM_STATIC_IMPORTS_PER_MODULE } from "./gen-code-splitting-case.js";
+import {
+	NUM_STATIC_MODULES,
+	NUM_REUSE_IMPORTS_PER_MODULE,
+	NUM_STATIC_IMPORTS_PER_MODULE,
+} from "./gen-code-splitting-case.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function main() {
-	const map = []
+	const map = [];
 	for (let i = 0; i < NUM_STATIC_MODULES; i += NUM_STATIC_IMPORTS_PER_MODULE) {
 		// imports from i to i + NUM_STATIC_IMPORTS_PER_MODULE
-		const depth = i / NUM_STATIC_IMPORTS_PER_MODULE
-		map[depth] = []
+		const depth = i / NUM_STATIC_IMPORTS_PER_MODULE;
+		map[depth] = [];
 
 		// reuse imports
 		for (let j = 0; j < NUM_REUSE_IMPORTS_PER_MODULE; j++) {
 			let random = Math.round(Math.random() * i);
 			if (random < i) {
 				if (!map[depth].includes(random)) {
-					map[depth].push(random)
+					map[depth].push(random);
 				}
 			}
 		}
 	}
 
-	fs.writeFile(path.join(__dirname, `./code-splitting-case-random-table.json`), JSON.stringify(map))
+	fs.writeFile(path.join(__dirname, `./code-splitting-case-random-table.json`), JSON.stringify(map));
 }
 
 main();

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -8,7 +8,7 @@ import {
 	fetchBenchmarkResult,
 	fetchCommitFiles,
 	fetchCommitBenchmarkResult,
-	fetchRspackBranchCommits
+	fetchRspackBranchCommits,
 } from "../lib/services.js";
 
 function getOverThresholdTags(diff) {
@@ -20,7 +20,7 @@ function getOverThresholdTags(diff) {
 					return null;
 				}
 			}
-			if (typeof data.baseMean !== 'number') {
+			if (typeof data.baseMean !== "number") {
 				return null;
 			}
 			if (tag.endsWith("memory")) {
@@ -47,10 +47,10 @@ function compareData(base, current) {
 		}
 
 		diff[key] = {
-			baseMean: baseValue?.mean ?? '-',
-			baseConfidence: baseValue?.confidence ?? '-',
+			baseMean: baseValue?.mean ?? "-",
+			baseConfidence: baseValue?.confidence ?? "-",
 			currentMean: currentValue.mean,
-			currentConfidence: currentValue.confidence
+			currentConfidence: currentValue.confidence,
 		};
 	}
 	return diff;
@@ -60,7 +60,7 @@ async function getResultsByCommit(commitSHA, files) {
 	return Promise.all(
 		files.map(async file => ({
 			name: basename(file, ".json"),
-			result: await fetchCommitBenchmarkResult(commitSHA, file)
+			result: await fetchCommitBenchmarkResult(commitSHA, file),
 		}))
 	);
 }
@@ -90,7 +90,7 @@ async function getResults(date, index, benchmarkDirectory) {
 			outputFiles.map(async item => {
 				return {
 					name: basename(item, ".json"),
-					result: JSON.parse(await readFile(resolve(benchmarkDirectory, item)))
+					result: JSON.parse(await readFile(resolve(benchmarkDirectory, item))),
 				};
 			})
 		);
@@ -101,7 +101,7 @@ async function getResults(date, index, benchmarkDirectory) {
 			.find(i => i.date === date)
 			.files.map(async file => ({
 				name: basename(file, ".json"),
-				result: await fetchBenchmarkResult(date, file)
+				result: await fetchBenchmarkResult(date, file),
 			}))
 	);
 }
@@ -113,7 +113,7 @@ async function resolveRef(ref, repository, index, buildInfo, benchmarkDirectory)
 		return {
 			results: await getResults("current", undefined, benchmarkDirectory),
 			label: "current",
-			commitSHA: undefined
+			commitSHA: undefined,
 		};
 	}
 	if (ref.startsWith("./") || ref.startsWith("../") || ref.startsWith("/")) {
@@ -121,14 +121,14 @@ async function resolveRef(ref, repository, index, buildInfo, benchmarkDirectory)
 		return {
 			results: await getResults("current", undefined, dir),
 			label: dir,
-			commitSHA: undefined
+			commitSHA: undefined,
 		};
 	}
 	if (isDate(ref)) {
 		return {
 			results: await getResults(ref, index, benchmarkDirectory),
 			label: ref,
-			commitSHA: buildInfo?.[ref]?.commitSHA
+			commitSHA: buildInfo?.[ref]?.commitSHA,
 		};
 	}
 	// branch name or commit hash — walk back until a commit with data is found
@@ -138,13 +138,13 @@ async function resolveRef(ref, repository, index, buildInfo, benchmarkDirectory)
 	return {
 		results: await getResultsByCommit(sha, files),
 		label: isCommitHash ? null : ref,
-		commitSHA: sha
+		commitSHA: sha,
 	};
 }
 
 function getCompareMetrics(name) {
 	if (name.includes("hmr")) {
-		return ["stats", "rss memory"]
+		return ["stats", "rss memory"];
 	}
 	return ["exec", "rss memory"];
 }
@@ -152,8 +152,8 @@ function getCompareMetrics(name) {
 function sortDiff(diff) {
 	const entries = Object.entries(diff);
 	const sorted = [
-		...entries.filter(([key]) => !key.includes('memory')),
-		...entries.filter(([key]) => key.includes('memory'))
+		...entries.filter(([key]) => !key.includes("memory")),
+		...entries.filter(([key]) => key.includes("memory")),
 	];
 	return Object.fromEntries(sorted);
 }
@@ -174,7 +174,7 @@ export async function compare(base, current, benchmarkDirectory, repository = "w
 
 	const [baseResolved, currentResolved] = await Promise.all([
 		resolveRef(base, repository, index, buildInfo, benchmarkDirectory),
-		resolveRef(current, repository, index, buildInfo, benchmarkDirectory)
+		resolveRef(current, repository, index, buildInfo, benchmarkDirectory),
 	]);
 
 	const baseData = {};
@@ -198,7 +198,7 @@ export async function compare(base, current, benchmarkDirectory, repository = "w
 		baseDate: baseResolved.label,
 		baseCommitSHA: baseResolved.commitSHA,
 		currentDate: currentResolved.label,
-		currentCommitSHA: currentResolved.commitSHA
+		currentCommitSHA: currentResolved.commitSHA,
 	});
 	const overThresholdTags = getOverThresholdTags(sortedDiff);
 	console.log(formatedTable);

--- a/lib/display.js
+++ b/lib/display.js
@@ -4,7 +4,7 @@ const typeOrder = {
 	time: 0,
 	memory: 1,
 	size: 2,
-	"gzip size": 3
+	"gzip size": 3,
 };
 const f = (name, value) => {
 	if (name.endsWith(" size")) return bytes(value);
@@ -18,10 +18,8 @@ const ratio = value => {
 const bytes = value => {
 	if (value === 0) return `-`;
 	if (value > 1024 * 102400) return `${Math.round(value / 1024 / 1024)} MiB`;
-	if (value > 1024 * 10240)
-		return `${Math.round(value / 1024 / 102.4) / 10} MiB`;
-	if (value > 1024 * 1024)
-		return `${Math.round(value / 1024 / 10.24) / 100} MiB`;
+	if (value > 1024 * 10240) return `${Math.round(value / 1024 / 102.4) / 10} MiB`;
+	if (value > 1024 * 1024) return `${Math.round(value / 1024 / 10.24) / 100} MiB`;
 	if (value > 102400) return `${Math.round(value / 1024)} KiB`;
 	if (value > 10240) return `${Math.round(value / 102.4) / 10} KiB`;
 	if (value > 1024) return `${Math.round(value / 10.24) / 100} KiB`;
@@ -43,23 +41,16 @@ function formatTable(entries, columns) {
 	if (entries.length === 0) {
 		return undefined;
 	}
-	const rows = entries.map(entry =>
-		Object.keys(columns).map(key => String(columns[key](entry)) || "")
-	);
+	const rows = entries.map(entry => Object.keys(columns).map(key => String(columns[key](entry)) || ""));
 	const header = Object.keys(columns);
-	const columnSizes = header.map((key, i) =>
-		Math.max(key.length, ...rows.map(row => row[i].length))
-	);
-	const getLine = l =>
-		`| ${l
-			.map((item, i) => `${item}${" ".repeat(columnSizes[i] - item.length)}`)
-			.join(" | ")} |`;
+	const columnSizes = header.map((key, i) => Math.max(key.length, ...rows.map(row => row[i].length)));
+	const getLine = l => `| ${l.map((item, i) => `${item}${" ".repeat(columnSizes[i] - item.length)}`).join(" | ")} |`;
 	return [
 		getLine(header),
 		`| ${columnSizes.map(s => "-".repeat(s)).join(" | ")} |`,
 		...rows.map(row => {
 			return getLine(row);
-		})
+		}),
 	].join("\n");
 }
 
@@ -73,39 +64,35 @@ export function formatDiffTable({ diff, baseDate, baseCommitSHA, currentDate, cu
 	const buildTitle = (label, commitSHA) => {
 		const parts = [];
 		if (label) parts.push(label);
-		if (commitSHA) parts.push(`[${commitSHA.slice(0, 7)}](https://github.com/web-infra-dev/rspack/commit/${commitSHA})`);
+		if (commitSHA)
+			parts.push(`[${commitSHA.slice(0, 7)}](https://github.com/web-infra-dev/rspack/commit/${commitSHA})`);
 		return `(${parts.join(" ")})`;
 	};
 
 	const baseTitle = `Base ${buildTitle(baseDate, baseCommitSHA)}`;
-	const currentTitle = currentDate && currentDate !== "current"
-		? `Current ${buildTitle(currentDate, currentCommitSHA)}`
-		: "Current";
+	const currentTitle =
+		currentDate && currentDate !== "current" ? `Current ${buildTitle(currentDate, currentCommitSHA)}` : "Current";
 
 	const columns = {
 		Name: l => l.name,
 		[baseTitle]: l => {
-			if (typeof l.baseMean !== 'number') {
-				return '-';
+			if (typeof l.baseMean !== "number") {
+				return "-";
 			}
 			return `${f(l.name, l.baseMean)} ± ${f(l.name, l.baseConfidence)}`;
 		},
-		[currentTitle]: l =>
-			`${f(l.name, l.currentMean)} ± ${f(l.name, l.currentConfidence)}`,
+		[currentTitle]: l => `${f(l.name, l.currentMean)} ± ${f(l.name, l.currentConfidence)}`,
 		Change: l => {
-			if (typeof l.baseMean !== 'number') {
-				return '-';
+			if (typeof l.baseMean !== "number") {
+				return "-";
 			}
-			const percent = (
-				((l.currentMean - l.baseMean) * 100) /
-				l.baseMean
-			).toFixed(2);
+			const percent = (((l.currentMean - l.baseMean) * 100) / l.baseMean).toFixed(2);
 			if (percent > 0) {
 				return `+${percent} %`;
 			} else {
 				return `${percent} %`;
 			}
-		}
+		},
 	};
 	return formatTable(entries, columns);
 }
@@ -113,7 +100,7 @@ export function formatDiffTable({ diff, baseDate, baseCommitSHA, currentDate, cu
 export function formatResultTable(result, { verbose, limit, threshold }) {
 	let entries = Object.keys(result).map(key => ({
 		name: key,
-		...result[key]
+		...result[key],
 	}));
 	entries.sort((a, b) => {
 		const aType = getType(a.name);
@@ -144,9 +131,9 @@ export function formatResultTable(result, { verbose, limit, threshold }) {
 					high: l => f(l.name, l.high),
 					con: l => f(l.name, l.confidence),
 					con: l => f(l.name, l.confidence),
-					n: l => `${l.count}`
+					n: l => `${l.count}`,
 			  }
-			: undefined)
+			: undefined),
 	};
 	return formatTable(entries, columns);
 }

--- a/lib/gen-code-splitting-case.js
+++ b/lib/gen-code-splitting-case.js
@@ -3,9 +3,9 @@ import path from "path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const getRandomTable = JSON.parse(await fs.readFile(
-	path.resolve(__dirname, "./code-splitting-case-random-table.json")
-));
+const getRandomTable = JSON.parse(
+	await fs.readFile(path.resolve(__dirname, "./code-splitting-case-random-table.json"))
+);
 
 export const NUM_STATIC_MODULES = 10_000;
 export const NUM_STATIC_IMPORTS_PER_MODULE = 10;
@@ -27,10 +27,7 @@ function Navbar({ show }) {
 export default Navbar`;
 
 	await fs.mkdir(path.join(CONTEXT, "./leaves"), { recursive: true });
-	await fs.writeFile(
-		path.join(CONTEXT, `./leaves/Component-${index}.jsx`),
-		code
-	);
+	await fs.writeFile(path.join(CONTEXT, `./leaves/Component-${index}.jsx`), code);
 }
 
 const generated = new Set();
@@ -62,9 +59,7 @@ async function genDynamicModule(index = 0) {
 
 	for (let i = 0; i < randomTable[depth].length; i++) {
 		const randomIdx = randomTable[depth][i];
-		reusedStaticImports.push(
-			`import Comp${randomIdx} from '../leaves/Component-${randomIdx}.jsx'`
-		);
+		reusedStaticImports.push(`import Comp${randomIdx} from '../leaves/Component-${randomIdx}.jsx'`);
 		access.push(`Comp${randomIdx}`);
 	}
 
@@ -88,8 +83,5 @@ ${dynamicImports.join("\n")}
 export default ${index};`;
 
 	await fs.mkdir(path.join(CONTEXT, "./dynamic"), { recursive: true });
-	await fs.writeFile(
-		path.join(CONTEXT, `./dynamic/dynamic-${depth}.jsx`),
-		code
-	);
+	await fs.writeFile(path.join(CONTEXT, `./dynamic/dynamic-${depth}.jsx`), code);
 }

--- a/lib/scenarios/build-plugin.js
+++ b/lib/scenarios/build-plugin.js
@@ -22,8 +22,7 @@ export default class BuildPlugin {
 		(compiler.hooks.afterDone || compiler.hooks.done).tap("BuildPlugin", () => {
 			setTimeout(() => {
 				if (counter === WARMUP_BUILDS) console.log("#!# start");
-				if (isWatching && !isLazyCompilation && counter <= TOTAL_BUILDS)
-					console.log("#!# next");
+				if (isWatching && !isLazyCompilation && counter <= TOTAL_BUILDS) console.log("#!# next");
 				if (isWatching && isLazyCompilation && firstRun) {
 					console.log("#!# dev");
 				}
@@ -51,7 +50,7 @@ export default class BuildPlugin {
 			const { logging, time } = stats.toJson({
 				all: false,
 				timings: true,
-				logging: "verbose"
+				logging: "verbose",
 			});
 			console.log(`#!# stats = ${time}`);
 			const memoryUsage = process.memoryUsage();
@@ -76,8 +75,7 @@ export default class BuildPlugin {
 							const ratio = (args[1] / args[2]) * 100;
 							console.log(`#!# ${name}.${args[0]} = ${ratio}`);
 						} else {
-							const [, label, ratio] =
-								/^(.+): ([\d.]+)% \(([\d.\/]+)\/([\d.\/]+)\)$/.exec(message);
+							const [, label, ratio] = /^(.+): ([\d.]+)% \(([\d.\/]+)\/([\d.\/]+)\)$/.exec(message);
 							console.log(`#!# ${name}.${label} = ${ratio}`);
 						}
 					}
@@ -90,12 +88,7 @@ export default class BuildPlugin {
 			const name = _name.replace(/^webpack\./, "");
 			if (type !== "time") return;
 			const ms = args[1] * 1000 + args[2] / 1000000;
-			console.log(
-				`#!# ${name}.${args[0].replace(
-					/restore cache content \d.+$/,
-					"restore cache content"
-				)} = ${ms}`
-			);
+			console.log(`#!# ${name}.${args[0].replace(/restore cache content \d.+$/, "restore cache content")} = ${ms}`);
 		};
 	}
 }

--- a/lib/scenarios/index.js
+++ b/lib/scenarios/index.js
@@ -3,12 +3,7 @@ import { readFile, unlink, writeFile } from "fs/promises";
 import { fileURLToPath } from "url";
 import actionsCore from "@actions/core";
 import { isGitHubActions, runCommand, openPage } from "../utils.js";
-import {
-	getDirSizes,
-	calcStatistics,
-	clearCaches,
-	getHmrConfig
-} from "./utils.js";
+import { getDirSizes, calcStatistics, clearCaches, getHmrConfig } from "./utils.js";
 
 const rootDir = path.resolve(fileURLToPath(import.meta.url), "../../..");
 
@@ -30,10 +25,7 @@ async function runRspack(ctx) {
 				counter++;
 				if (dataSetCounter >= 0) dataSetCounter++;
 				for (const item of ctx.hmrConfig) {
-					const content = item.generateContent(
-						ctx.originalFiles[item.rebuildChangeFile],
-						counter
-					);
+					const content = item.generateContent(ctx.originalFiles[item.rebuildChangeFile], counter);
 					await writeFile(item.rebuildChangeFile, content);
 				}
 			});
@@ -66,8 +58,8 @@ async function runRspack(ctx) {
 			lines.forEach(processLine);
 		},
 		env: {
-			NODE_OPTIONS: "--max-old-space-size=8192"
-		}
+			NODE_OPTIONS: "--max-old-space-size=8192",
+		},
 	});
 
 	data.exec = Date.now() - start;
@@ -96,7 +88,7 @@ export function getScenario(caseName) {
 				caseDir,
 				originalFiles: {
 					[configFilePath]: config,
-					...hmrConfig.originalFiles
+					...hmrConfig.originalFiles,
 				},
 				config: `${config}
 config.plugins = config.plugins || [];
@@ -108,7 +100,7 @@ config.plugins.push(new BuildPlugin());`,
 				runTimes: 5,
 				timeout: 5 * 60 * 1000,
 				runData: [],
-				result: {}
+				result: {},
 			};
 		},
 		async generate(ctx) {
@@ -118,26 +110,19 @@ config.plugins.push(new BuildPlugin());`,
 				actionsCore.endGroup();
 			}
 
-			await writeFile(
-				path.resolve(ctx.caseDir, "rspack.config.js"),
-				ctx.config
-			);
-			const rspackDir =
-				process.env.RSPACK_DIR || path.resolve(rootDir, ".rspack");
+			await writeFile(path.resolve(ctx.caseDir, "rspack.config.js"), ctx.config);
+			const rspackDir = process.env.RSPACK_DIR || path.resolve(rootDir, ".rspack");
 			console.log("Create Rspack package link");
-			await runCommand("mkdir", [
-				"-p",
-				path.resolve(rootDir, "node_modules/@rspack")
-			]);
+			await runCommand("mkdir", ["-p", path.resolve(rootDir, "node_modules/@rspack")]);
 			await runCommand("ln", [
 				"-nsf",
 				path.resolve(rspackDir, "packages/rspack"),
-				path.resolve(rootDir, "node_modules/@rspack/core")
+				path.resolve(rootDir, "node_modules/@rspack/core"),
 			]);
 			await runCommand("ln", [
 				"-nsf",
 				path.resolve(rspackDir, "packages/rspack-cli"),
-				path.resolve(rootDir, "node_modules/@rspack/cli")
+				path.resolve(rootDir, "node_modules/@rspack/cli"),
 			]);
 		},
 		async warmup(ctx) {
@@ -145,9 +130,7 @@ config.plugins.push(new BuildPlugin());`,
 
 			await runRspack({
 				...ctx,
-				rspackArgs: ctx.rspackArgs
-					.filter(a => a !== "--watch")
-					.filter(a => a !== "dev")
+				rspackArgs: ctx.rspackArgs.filter(a => a !== "--watch").filter(a => a !== "dev"),
 			});
 		},
 		async run(ctx) {
@@ -178,6 +161,6 @@ config.plugins.push(new BuildPlugin());`,
 				})
 			);
 			process.chdir(rootDir);
-		}
+		},
 	};
 }

--- a/lib/scenarios/utils.js
+++ b/lib/scenarios/utils.js
@@ -6,12 +6,12 @@ function rmdir(p) {
 		return fs.rm(p, {
 			force: true,
 			maxRetries: 10,
-			recursive: true
+			recursive: true,
 		});
 	} else {
 		return fs.rmdir(p, {
 			maxRetries: 10,
-			recursive: true
+			recursive: true,
 		});
 	}
 }
@@ -46,14 +46,13 @@ export async function getHmrConfig(filePath) {
 	);
 	return {
 		originalFiles,
-		config
+		config,
 	};
 }
 
 const T_TABLE = [
-	12.71, 4.303, 3.182, 2.776, 2.571, 2.447, 2.365, 2.306, 2.262, 2.228, 2.201,
-	2.179, 2.16, 2.145, 2.131, 2.12, 2.11, 2.101, 2.093, 2.086, 2.08, 2.074,
-	2.069, 2.064, 2.06, 2.056, 2.052, 2.048, 2.045, 2.042
+	12.71, 4.303, 3.182, 2.776, 2.571, 2.447, 2.365, 2.306, 2.262, 2.228, 2.201, 2.179, 2.16, 2.145, 2.131, 2.12, 2.11,
+	2.101, 2.093, 2.086, 2.08, 2.074, 2.069, 2.064, 2.06, 2.056, 2.052, 2.048, 2.045, 2.042,
 ];
 const tDist95Two = n => {
 	if (n <= 1) return 12.71;
@@ -75,11 +74,9 @@ export function calcStatistics(data) {
 		} else {
 			values.sort();
 			const mean = values.reduce((sum, v) => sum + v, 0) / values.length;
-			const variance =
-				values.reduce((sum, v) => sum + (mean - v) ** 2, 0) / values.length;
+			const variance = values.reduce((sum, v) => sum + (mean - v) ** 2, 0) / values.length;
 			const stdDev = Math.sqrt(variance);
-			const confidence =
-				(tDist95Two(values.length - 1) * stdDev) / Math.sqrt(values.length);
+			const confidence = (tDist95Two(values.length - 1) * stdDev) / Math.sqrt(values.length);
 			const low = Math.max(0, mean - confidence);
 			const high = mean + confidence;
 			stats[key] = {
@@ -95,7 +92,7 @@ export function calcStatistics(data) {
 				confidence: high - low,
 				low,
 				high,
-				count: values.length
+				count: values.length,
 			};
 		}
 	}

--- a/lib/services.js
+++ b/lib/services.js
@@ -5,7 +5,7 @@ if (process.env.http_proxy) {
 	setGlobalDispatcher(agent);
 }
 
-const fetchPrefix = 'https://raw.githubusercontent.com/web-infra-dev/rspack-ecosystem-benchmark/data';
+const fetchPrefix = "https://raw.githubusercontent.com/web-infra-dev/rspack-ecosystem-benchmark/data";
 
 /**
  * Fetch the build information from a JSON file.
@@ -33,7 +33,7 @@ export async function fetchIndex() {
 			mappings[date] = [];
 			result.push({
 				date,
-				files: mappings[date]
+				files: mappings[date],
 			});
 		}
 		mappings[date].push(fileName);
@@ -53,10 +53,10 @@ export async function fetchBenchmarkResult(date, file) {
 	return await res.json();
 }
 
-const githubApiPrefix = 'https://api.github.com';
+const githubApiPrefix = "https://api.github.com";
 const githubApiHeaders = {
-	Accept: 'application/vnd.github.v3+json',
-	...(process.env.GITHUB_TOKEN && { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` })
+	Accept: "application/vnd.github.v3+json",
+	...(process.env.GITHUB_TOKEN && { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }),
 };
 
 function getCommitDataPath(sha) {
@@ -78,7 +78,7 @@ export async function fetchCommitFiles(commitSHA) {
 	);
 	if (!res.ok) return null;
 	const items = await res.json();
-	return Array.isArray(items) ? items.map(f => f.name).filter(f => f.endsWith('.json')) : null;
+	return Array.isArray(items) ? items.map(f => f.name).filter(f => f.endsWith(".json")) : null;
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 import { spawn } from "child_process";
 import { stat } from "fs/promises";
-import puppeteer from 'puppeteer'
+import puppeteer from "puppeteer";
 
 export async function useAddons(addons, stage, ...args) {
 	for (const item of addons) {
@@ -8,11 +8,7 @@ export async function useAddons(addons, stage, ...args) {
 	}
 }
 
-export async function runCommand(
-	command,
-	args,
-	{ verbose = true, env, onData } = {}
-) {
+export async function runCommand(command, args, { verbose = true, env, onData } = {}) {
 	const hasOnData = typeof onData === "function";
 	const stdio = verbose ? "inherit" : "ignore";
 	const p = spawn(command, args, {
@@ -21,18 +17,17 @@ export async function runCommand(
 		stderr: "inherit",
 		env: env
 			? {
-				...process.env,
-				...env
-			}
-			: undefined
+					...process.env,
+					...env,
+			  }
+			: undefined,
 	});
 	if (hasOnData) {
 		p.stdout.on("data", onData);
 	}
 
 	const exitCode = await new Promise(resolve => p.once("exit", resolve));
-	if (exitCode !== 0)
-		throw new Error(`${command} ${args.join(" ")} failed with ${exitCode}`);
+	if (exitCode !== 0) throw new Error(`${command} ${args.join(" ")} failed with ${exitCode}`);
 }
 
 export function getType(metric) {
@@ -55,15 +50,14 @@ export function formatDate(timestamp) {
 	const year = time.getFullYear();
 	const month = time.getMonth() + 1;
 	const day = time.getDate();
-	return `${year}-${month < 10 ? "0" + month : month}-${day < 10 ? "0" + day : day
-		}`;
+	return `${year}-${month < 10 ? "0" + month : month}-${day < 10 ? "0" + day : day}`;
 }
 
 export async function openPage(url) {
 	const browser = await puppeteer.launch();
 	const page = await browser.newPage();
 	await page.goto(url, {
-		waitUntil: "networkidle2"
+		waitUntil: "networkidle2",
 	});
 	await browser.close();
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "zx": "^8.1.1"
   },
   "packageManager": "pnpm@8.14.3",
+  "scripts": {
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
   "devDependencies": {
     "generate-package-json-webpack-plugin": "^2.6.0",
     "prettier": "^2.6.2"


### PR DESCRIPTION
## Summary
- Add `format` and `format:check` npm scripts using Prettier
- Add `.github/workflows/format.yml` to run `format:check` on push to main and on PRs
- Tweak `.prettierrc` (`arrowParens: avoid`, `printWidth: 120`) and apply formatting across the repo

## Test plan
- [ ] CI `Format Check` job passes on this PR