### PR TITLE
fix(docs): paginate commits API with uniform per_page to avoid overlap

### DIFF
--- a/docs/by_commits.html
+++ b/docs/by_commits.html
@@ -8,7 +8,7 @@
 		<h1>Rspack/benchmark</h1>
 		<div class="per-page-container">
 			Commits to fetch:
-			<input class="per-page-input" type="number" min="1" max="100" step="1" />
+			<input class="per-page-input" type="number" min="1" max="500" step="1" />
 			<span class="per-page-apply">Apply</span>
 		</div>
 		<div class="action-container">

--- a/docs/by_commits.js
+++ b/docs/by_commits.js
@@ -143,23 +143,37 @@ class DataCenter {
 	// fetch index and latest data
 	async initialize() {
 		const queryParams = new URLSearchParams(window.location.search);
-		const perPage = parseInt(queryParams.get("per_page") || "50", 10) || 50;
+		const total = parseInt(queryParams.get("per_page") || "50", 10) || 50;
+
+		// GitHub commits API caps per_page at 100 — fan out into parallel pages
+		// when the requested total exceeds that, then concat in chronological order.
+		// NOTE: the offset is (page-1)*per_page, so all pages must share the same
+		// per_page (use MAX_PER_PAGE for every page and trim the tail). Mixing
+		// per_page values across pages causes overlap between consecutive pages.
+		const MAX_PER_PAGE = 100;
+		const perPage = Math.min(total, MAX_PER_PAGE);
+		const pageCount = Math.max(1, Math.ceil(total / perPage));
+
+		const headers = this.githubToken ? { Authorization: `Bearer ${this.githubToken}` } : {};
 
 		try {
-			const commits = await fetch(`https://api.github.com/repos/web-infra-dev/rspack/commits?per_page=${perPage}`, {
-				headers: this.githubToken
-					? {
-							Authorization: `Bearer ${this.githubToken}`,
-					  }
-					: {},
-			}).then(res => {
-				if (!res.ok) {
-					showGithubTokenModal();
+			const pages = await Promise.all(
+				Array.from({ length: pageCount }, (_, i) => {
+					const page = i + 1;
+					const url = `https://api.github.com/repos/web-infra-dev/rspack/commits?per_page=${perPage}&page=${page}`;
+					return fetch(url, { headers }).then(res => {
+						if (!res.ok) {
+							showGithubTokenModal();
+							throw new Error(`GitHub API ${res.status}`);
+						}
+						return res.json();
+					});
+				})
+			);
 
-					throw new Error("403 Forbidden");
-				}
-				return res.json();
-			});
+			// Each page is newest→oldest; page 1 is newest. Flatten, trim to `total`,
+			// then reverse so `this.commits` runs oldest→newest (chart x-axis order).
+			const commits = pages.flat().slice(0, total);
 
 			this.commits = commits
 				.map(({ sha, html_url, commit: { message, author } }) => ({
@@ -583,7 +597,7 @@ function initializePerPageInput() {
 	input.value = current;
 
 	const commit = () => {
-		const next = Math.max(1, Math.min(100, parseInt(input.value, 10) || 0));
+		const next = Math.max(1, Math.min(500, parseInt(input.value, 10) || 0));
 		if (!next || next === current) return;
 		const nextParams = new URLSearchParams(window.location.search);
 		nextParams.set("per_page", String(next));


### PR DESCRIPTION
## Summary
- Previously, when the requested total was not a multiple of 100, the last page request used a smaller `per_page` (e.g. `?per_page=50&page=2`). GitHub's offset is `(page - 1) * per_page`, so that page overlaps with page 1 instead of continuing past it — e.g. `?per_page=150` returned commits 1..100 followed by commits 51..100, duplicating ~50 commits and producing the anomalous series on the binary size chart.
- Fix: use the same `per_page` (capped at 100) for every page and trim the flattened result to the requested total.
- Raise the input `max` from 100 to 500 so the uniform-page fan-out actually covers the value range the UI now supports.

## Test plan
- [ ] `pnpm run docs:preview` then visit `http://localhost:3000/by_commits?per_page=150`
- [ ] Verify two parallel requests in DevTools Network: `per_page=100&page=1` and `per_page=100&page=2` (same `per_page`)
- [ ] Confirm SHAs across the two responses do not overlap (first SHA of page 2 is not present in page 1)
- [ ] Binary Size chart renders a single smooth line per series (no zigzag from duplicated commits)
- [ ] Smaller totals (e.g. `?per_page=50`) still issue a single request
- [ ] Larger totals (e.g. `?per_page=300`) issue three `per_page=100` requests with distinct SHAs