### PR TITLE
chore(ci): switch CI bench workflow to workflow_dispatch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,10 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "**/*.md"
-  pull_request:
-    types: [opened, synchronize]
-    branches: [main]
-    paths-ignore:
-      - "**/*.md"
+  workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:


### PR DESCRIPTION
## Summary
- Remove `push` and `pull_request` triggers from `.github/workflows/ci.yml`; keep only `workflow_dispatch`.
- Avoid consuming self-hosted benchmark runner resources on every push / PR.
- Bench can still be run on demand via the "Run workflow" button.

## Test plan
- [ ] Confirm the CI workflow no longer auto-runs on this PR.
- [ ] Manually trigger the workflow via `workflow_dispatch` to verify it still executes successfully.