### PR TITLE
fix: numeric median sort + show sub-ms time precision in charts

### DIFF
--- a/docs/by_commits.js
+++ b/docs/by_commits.js
@@ -9,8 +9,8 @@ const getFetchPrefix = () => {
 const fetchPrefix = getFetchPrefix();
 
 const formatTime = (value, maxValue) => {
-	if (maxValue > 10000) return `${value / 1000} s`;
-	return `${value} ms`;
+	if (maxValue > 10000) return `${(value / 1000).toFixed(3)} s`;
+	return `${value.toFixed(3)} ms`;
 };
 
 const formatSize = (value, maxValue) => {

--- a/docs/index.js
+++ b/docs/index.js
@@ -9,8 +9,8 @@ const getFetchPrefix = () => {
 const fetchPrefix = getFetchPrefix();
 
 const formatTime = (value, maxValue) => {
-	if (maxValue > 10000) return `${value / 1000} s`;
-	return `${value} ms`;
+	if (maxValue > 10000) return `${(value / 1000).toFixed(3)} s`;
+	return `${value.toFixed(3)} ms`;
 };
 
 const formatSize = (value, maxValue) => {

--- a/lib/scenarios/utils.js
+++ b/lib/scenarios/utils.js
@@ -72,7 +72,7 @@ export function calcStatistics(data) {
 		if (typeof values[0] === "object") {
 			stats[key] = calcStatistics(values);
 		} else {
-			values.sort();
+			values.sort((a, b) => a - b);
 			const mean = values.reduce((sum, v) => sum + v, 0) / values.length;
 			const variance = values.reduce((sum, v) => sum + (mean - v) ** 2, 0) / values.length;
 			const stdDev = Math.sqrt(variance);


### PR DESCRIPTION
## Why

Two small precision fixes for benchmark stats and display:

1. **`calcStatistics` median is wrong for multi-digit values.** `values.sort()` defaults to lexicographic string order, so e.g. `[12, 9, 3]` sorts to `["12", "3", "9"]` and reports `median = 3` instead of `9`. `min`/`max` are unaffected because they use `Math.min`/`Math.max`.

2. **Chart formatTime truncates ms display to integer.** Pairs with rspack web-infra-dev/rspack#14049 which makes `logger.time` emit sub-millisecond floats — without this change the chart axis and tooltip would still render `154 ms` instead of `154.382 ms`, hiding the µs-scale precision the data now carries.

## Before / After

```
calcStatistics([12, 9, 3]).median  →  3       // before
calcStatistics([12, 9, 3]).median  →  9       // after

formatTime(0.019542)               →  "0 ms"     // before
formatTime(0.019542)               →  "0.020 ms" // after
```