### PR TITLE
Restrict persistent cache hit rate output to persistent-hot cases

### DIFF
--- a/lib/compare.js
+++ b/lib/compare.js
@@ -161,10 +161,10 @@ function sortDiff(diff) {
 
 function formatPersistentCacheHitRate(label, results) {
 	const HIT_RATE_KEY = "SwcJsMinimizerRspackPlugin.minimize persistent cache";
-	const cases = results.filter(({ result }) => result[HIT_RATE_KEY] !== undefined);
+	const cases = results.filter(({ name, result }) => name.includes("persistent-hot") && result[HIT_RATE_KEY] !== undefined);
 
 	if (cases.length === 0) {
-		return `${label} persistent cache hit rate: N/A`;
+		return null;
 	}
 
 	const misses = cases.filter(({ result }) => result[HIT_RATE_KEY].min !== 100 || result[HIT_RATE_KEY].max !== 100);
@@ -232,7 +232,7 @@ export async function compare(base, current, benchmarkDirectory, repository = "w
 	].filter(Boolean);
 	if (hitRateSummaries.length > 0) {
 		console.log("");
-		console.log(hitRateSummaries.join("\n"));
+		console.log(hitRateSummaries.join("\n\n"));
 	}
 
 	if (overThresholdTags.length > 0) {


### PR DESCRIPTION
## Summary
- Only include `persistent-hot` benchmark cases in persistent cache hit rate reporting.
- Suppress the hit rate section entirely when no hot cases are present, instead of showing `N/A`.
- Keep hit rate summaries separated by a blank line for readability.

## Testing
- Not run (not requested).