### PR TITLE
chore(ci): read benchmark data via authenticated API to avoid CDN 429

### DIFF
--- a/.github/workflows/bench_rspack_commit.yml
+++ b/.github/workflows/bench_rspack_commit.yml
@@ -65,6 +65,8 @@ jobs:
           merge-multiple: true
       - id: print-results
         name: Print results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           result=$(node bin/cli.js compare --base latest --current current)
           echo "$result"

--- a/.github/workflows/bench_rspack_pr.yml
+++ b/.github/workflows/bench_rspack_pr.yml
@@ -89,6 +89,8 @@ jobs:
           merge-multiple: true
       - id: print-results
         name: Print results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           result=$(node bin/cli.js compare --base latest --current current)
           echo "$result"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
         run: node bin/cli.js bench --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - id: print-compare-results
         name: Print compare results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           result=$(node bin/cli.js compare --base latest --current current)
           echo "$result"

--- a/.github/workflows/scheduled_bench.yml
+++ b/.github/workflows/scheduled_bench.yml
@@ -27,6 +27,8 @@ jobs:
         run: node bin/cli.js bench
       - id: print-compare-results
         name: Print compare results
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           result=$(node bin/cli.js compare --base latest --current current)
           echo "$result"

--- a/lib/services.js
+++ b/lib/services.js
@@ -5,15 +5,13 @@ if (process.env.http_proxy) {
 	setGlobalDispatcher(agent);
 }
 
-const fetchPrefix = "https://raw.githubusercontent.com/web-infra-dev/rspack-ecosystem-benchmark/data";
-
 /**
  * Fetch the build information from a JSON file.
  *
  * @returns {Promise<Object.<string, {commitSHA: string}>>}
  */
 export async function fetchBuildInfo() {
-	return fetch(`${fetchPrefix}/build-info.json`).then(res => res.json());
+	return fetchDataFile("build-info.json").then(res => res.json());
 }
 
 /**
@@ -22,7 +20,7 @@ export async function fetchBuildInfo() {
  * @returns {Promise<{date: string, files: string[]}[]>>} A promise that resolves to an object mapping dates to arrays of file names.
  */
 export async function fetchIndex() {
-	const index = await fetch(`${fetchPrefix}/index.txt`).then(res => res.text());
+	const index = await fetchDataFile("index.txt").then(res => res.text());
 	const lines = index.split("\n").filter(Boolean);
 
 	const result = [];
@@ -49,7 +47,7 @@ export async function fetchIndex() {
  * @returns {Promise<{[key: string]: Object.<string, number>}>} A promise that resolves to the benchmark result data.
  */
 export async function fetchBenchmarkResult(date, file) {
-	const res = await fetch(`${fetchPrefix}/${date}/${file}`);
+	const res = await fetchDataFile(`${date}/${file}`);
 	return await res.json();
 }
 
@@ -61,6 +59,25 @@ const githubApiHeaders = {
 
 function getCommitDataPath(sha) {
 	return `commits/${sha.slice(0, 2)}/${sha.slice(2)}`;
+}
+
+/**
+ * Reads a file from the `data` branch through the authenticated Contents API
+ * (raw media type) instead of the anonymous raw.githubusercontent.com CDN,
+ * which rate-limits per shared runner IP and returns 429. ref: rspack#14730
+ *
+ * @param {string} path - file path relative to the data branch root
+ * @returns {Promise<Response>}
+ */
+async function fetchDataFile(path) {
+	const res = await fetch(
+		`${githubApiPrefix}/repos/web-infra-dev/rspack-ecosystem-benchmark/contents/${path}?ref=data`,
+		{ headers: { ...githubApiHeaders, Accept: "application/vnd.github.raw" } }
+	);
+	if (!res.ok) {
+		throw new Error(`Failed to fetch ${path} from data branch: ${res.status} ${res.statusText}`);
+	}
+	return res;
 }
 
 /**
@@ -87,8 +104,7 @@ export async function fetchCommitFiles(commitSHA) {
  * @returns {Promise<{[key: string]: Object.<string, number>}>}
  */
 export async function fetchCommitBenchmarkResult(commitSHA, file) {
-	const path = getCommitDataPath(commitSHA);
-	const res = await fetch(`${fetchPrefix}/${path}/${file}`);
+	const res = await fetchDataFile(`${getCommitDataPath(commitSHA)}/${file}`);
 	return res.json();
 }
 


### PR DESCRIPTION
## Why

The ecosystem-benchmark `bench` job fails at the `compare` step with a confusing `SyntaxError` that is actually a `429 Too Many Requests`:

```
429: Too Many Requests
   ^
SyntaxError: Unexpected non-whitespace character after JSON at position 3
    at JSON.parse (<anonymous>)
    at async .../lib/compare.js:64   // fetchCommitBenchmarkResult
    at async Promise.all (index 28)  // 29 result files fetched in parallel
```

The 429 comes from **anonymous** `raw.githubusercontent.com`, which rate-limits per source IP. GitHub Actions runners share an IP pool, so fanning out ~29 parallel result-file reads gets throttled. The response body (`429: Too Many Requests`) is then fed straight into `JSON.parse`, masking the real cause.

Same class of issue — and same fix — as rspack#14730.

## What

**1. Read data through the authenticated Contents API** (`lib/services.js`)

Read all `data`-branch files via `api.github.com/.../contents/...?ref=data` (`Accept: application/vnd.github.raw`) instead of the anonymous CDN.

- Rate limit becomes 5000 req/h **per token** instead of the shared anonymous per-IP bucket, so the parallel fetch no longer needs throttling.
- New `fetchDataFile` helper **throws on non-2xx**, replacing the misleading `JSON.parse("429: ...")` crash with a readable error.
- Removed the now-unused anonymous `fetchPrefix` CDN base.

**2. Provide the token where `compare` runs** (workflows)

The authenticated path needs `process.env.GITHUB_TOKEN`, which GitHub Actions does **not** expose to `run:` steps automatically. The rspack-side compare action already wires it; the compare steps in this repo's own workflows did not. Added `env.GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the `compare` step in `scheduled_bench`, `bench_rspack_commit`, `bench_rspack_pr`, and `ci`. Without this, those runs would fall back to anonymous `api.github.com` (60 req/h) — worse than before.

## Verification

Ran the exact failing path against the same base commit `34f8b02` that 429'd: walked the branch, listed the data commit, fetched **all 29 result files in parallel** — all parsed OK, no 429.

Failing run: https://github.com/web-infra-dev/rspack/actions/runs/28920821256/job/85798861766
